### PR TITLE
feat: Add support for dynamic scope and bot_prompt parameters in LINE authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-# OmniAuth Line
+# OmniAuth Line (Forked Version)
+This is a fork of the original [omniauth-line](https://github.com/kazasiki/omniauth-line) gem, modified to support additional dynamic parameters for authentication.
 
 This gem contains the Line OAuth2 Strategy for OmniAuth.
-
 Supports the OpenID Connect Web Login. Read the Line developers docs for more details: https://developers.line.me/en/docs/line-login/web/integrate-line-login/
+
+
+Modifications
+- Added support for scope and bot_prompt parameters, allowing more flexibility in permission requests and bot prompts during authentication.
+- Updated examples and documentation to illustrate usage of these new parameters.
 
 ## Using This Strategy
 
 First start by adding this gem to your Gemfile:
 
 ```ruby
-gem 'omniauth-line'
+gem 'omniauth-line', git: 'https://github.com/crzbread/omniauth-line.git', branch: 'master'
 ```
 
 Next, tell OmniAuth about this provider. For a Rails app, your `config/initializers/omniauth.rb` file should look like this:
@@ -20,6 +25,26 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :line, "Channel_ID", "Channel_Secret"
 end
 ```
+
+### New Features
+This gem now supports dynamically setting additional parameters for LINE authentication, specifically:
+
+- scope: Define the permissions requested during authentication. Default is "profile openid".
+- bot_prompt: Configure whether to prompt users to add a bot as a friend. Set to "normal" or "aggressive".
+For example, you can configure the scope and bot_prompt in your OmniAuth initializer as follows:
+
+```ruby
+# if use devise, config/initializers/devise.rb
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :line, "Channel_ID", "Channel_Secret",
+  scope: "profile openid email",
+  bot_prompt: "normal"
+end
+```
+### ⚠️ Important Note
+Testing for the new scope and bot_prompt parameters is currently not fully implemented.
+
+
 
 ## Authentication Hash
 An example auth hash available in `request.env['omniauth.auth']`:

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -41,6 +41,14 @@ module OmniAuth
         raise ::Timeout::Error
       end
 
+      def authorize_params
+        super.tap do |params|
+          # Only include specified parameters, ignoring any additional ones.
+          %i[scope bot_prompt].each do |key|
+            params[key] = options[key] if options[key]
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description: 
This PR enhances the omniauth-line strategy by adding support for dynamic parameters in the LINE authentication process, specifically scope and bot_prompt. These modifications provide more flexibility in setting permissions and customizing the user experience.

## Modifications
Added support for scope: Allows developers to specify the requested permissions during authentication. Defaults to "profile openid".
Added support for bot_prompt: Enables developers to control whether users are prompted to add a bot as a friend. Options include "normal" and "aggressive".
Updated documentation and examples: Added examples to the README to illustrate how to configure scope and bot_prompt.
## Important Note
Please note that testing for the new scope and bot_prompt parameters is currently incomplete. Further testing is advised before deploying to production environments.

Example Usage
In your Rails initializer, configure omniauth-line with the new options:

```ruby

Rails.application.config.middleware.use OmniAuth::Builder do
  provider :line, "Channel_ID", "Channel_Secret",
           scope: "profile openid email",
           bot_prompt: "normal"
end
```

## Additional Information
These changes maintain backward compatibility, so existing implementations of omniauth-line should continue to work without modification.